### PR TITLE
Add Navbar to Header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,6 +27,15 @@ export function Header() {
           <Button href="#">Get your tickets</Button>
         </div>
       </Container>
+      <Container>
+        <nav className='flex items-center justify-center'>
+          <ul className="flex items-center justify-center gap-8 px-8 py-4 overflow-x-auto font-mono text-sm text-blue-600 bg-blue-100 border-b rounded-full border-blue-900/10 sm:-mx-6 lg:mx-0 lg:justify-start">
+            <li><Link className='hover:underline hover:underline-offset-4 focus:font-bold focus:underline focus:underline-offset-4' href={'/'}>Home</Link></li>
+            <li><Link className='hover:underline hover:underline-offset-4 focus:font-bold focus:underline focus:underline-offset-4' href={'/become-sponsor'}>Event sponsorship</Link></li>
+            <li><Link className='hover:underline hover:underline-offset-4 focus:font-bold focus:underline focus:underline-offset-4' href={'/get-tickets'}>Get tickets</Link></li>
+          </ul>
+        </nav>
+      </Container>
     </header>
   )
 }

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,22 +1,16 @@
 import React from 'react'
 
-const PageTitle = ({ title }) => {
+const PageTitle = ({ title, description }) => {
   return (
     
-      <div className="relative py-20 sm:pb-24 sm:pt-36">
-        
-        <div className='px-4 mx-auto max-w-7xl sm:px-6 lg:px-8'>
-          <div className="max-w-2xl mx-auto lg:max-w-4xl lg:px-12">
-            <h1 className="text-5xl font-bold tracking-tighter text-blue-600 font-display sm:text-7xl">
-              <span className="sr-only">Ohio Devfest - </span>{title} test
-            </h1>
-            <div className="mt-6 space-y-6 text-2xl tracking-tight text-blue-900 font-display">
-              <p>
-                mt-6 space-y-6 text-2xl tracking-tight text-blue-900 font-display
-              </p>
-              
-          </div>
-        </div>
+      <div className="relative py-20 sm:pb-24 sm:pt-36">  
+        <div className='px-4 mx-auto max-w-7xl sm:px-6 lg:px-8'> 
+          <h1 className="text-5xl font-bold tracking-tighter text-blue-600 font-display sm:text-6xl">
+            <span className="sr-only">Ohio Devfest - </span>{title}
+          </h1>
+        <p className="mt-6 space-y-6 text-2xl tracking-tight text-blue-900 font-display">
+          {description}
+          </p>
       </div>
     </div>
   )

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+const PageTitle = ({ title }) => {
+  return (
+    
+      <div className="relative py-20 sm:pb-24 sm:pt-36">
+        
+        <div className='px-4 mx-auto max-w-7xl sm:px-6 lg:px-8'>
+          <div className="max-w-2xl mx-auto lg:max-w-4xl lg:px-12">
+            <h1 className="text-5xl font-bold tracking-tighter text-blue-600 font-display sm:text-7xl">
+              <span className="sr-only">Ohio Devfest - </span>{title} test
+            </h1>
+            <div className="mt-6 space-y-6 text-2xl tracking-tight text-blue-900 font-display">
+              <p>
+                mt-6 space-y-6 text-2xl tracking-tight text-blue-900 font-display
+              </p>
+              
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+export default PageTitle;

--- a/src/pages/become-sponsor.jsx
+++ b/src/pages/become-sponsor.jsx
@@ -1,25 +1,17 @@
 import Head from 'next/head'
-
-import { Hero } from '@/components/Hero'
 import { Newsletter } from '@/components/Newsletter'
-import { Schedule } from '@/components/Schedule'
-import { Speakers } from '@/components/Speakers'
-import { Sponsors } from '@/components/Sponsors'
 
-export default function Home() {
+export default function SponsorPage() {
   return (
     <>
       <Head>
-        <title>Ohio DevFest Hackathon & Conference</title>
+        <title>Event Sponsor</title>
         <meta
           name="description"
           content="The 2023 Ohio DevFest is a local tech conference hosted by Ohio-based Google Developer Groups (GDGs). It features talks, hands-on demos, workshops, and codelabs on the latest Google tech, plus featured talks intended to broaden interest and appeal."
         />
       </Head>
-      <Hero />
-      {/* <Speakers /> */}
-      {/* <Schedule /> */}
-      {/* <Sponsors /> */}
+
       <Newsletter />
     </>
   )

--- a/src/pages/become-sponsor.jsx
+++ b/src/pages/become-sponsor.jsx
@@ -1,18 +1,22 @@
 import Head from 'next/head'
+import  PageTitle  from '@/components/PageTitle'
 import { Newsletter } from '@/components/Newsletter'
 
-export default function SponsorPage() {
+const BecomeSponsorPage = () => {
+  const pageTitle = 'How to Become a sponsor'
+  const description = 'A bit of info introducing the sponsorship page'
   return (
     <>
       <Head>
-        <title>Event Sponsor</title>
+        <title>Ohio DevFest Hackathon & Conference</title>
         <meta
           name="description"
           content="The 2023 Ohio DevFest is a local tech conference hosted by Ohio-based Google Developer Groups (GDGs). It features talks, hands-on demos, workshops, and codelabs on the latest Google tech, plus featured talks intended to broaden interest and appeal."
         />
       </Head>
-
+      <PageTitle title={pageTitle} description={description} />
       <Newsletter />
     </>
   )
 }
+export default BecomeSponsorPage;

--- a/src/pages/get-tickets.jsx
+++ b/src/pages/get-tickets.jsx
@@ -1,26 +1,22 @@
 import Head from 'next/head'
-
-import { Hero } from '@/components/Hero'
 import { Newsletter } from '@/components/Newsletter'
-import { Schedule } from '@/components/Schedule'
-import { Speakers } from '@/components/Speakers'
-import { Sponsors } from '@/components/Sponsors'
+import  PageTitle  from '@/components/PageTitle'
 
-export default function Home() {
+const GetTicketsPage = () => {
+  const pageTitle = 'Get Tickets';
   return (
     <>
       <Head>
-        <title>Ohio DevFest Hackathon & Conference</title>
+        <PageTitle title={pageTitle} />
         <meta
           name="description"
           content="The 2023 Ohio DevFest is a local tech conference hosted by Ohio-based Google Developer Groups (GDGs). It features talks, hands-on demos, workshops, and codelabs on the latest Google tech, plus featured talks intended to broaden interest and appeal."
         />
       </Head>
-      <Hero />
-      {/* <Speakers /> */}
-      {/* <Schedule /> */}
-      {/* <Sponsors /> */}
+
+      <PageTitle />
       <Newsletter />
     </>
   )
 }
+export default GetTicketsPage;

--- a/src/pages/get-tickets.jsx
+++ b/src/pages/get-tickets.jsx
@@ -3,18 +3,20 @@ import { Newsletter } from '@/components/Newsletter'
 import  PageTitle  from '@/components/PageTitle'
 
 const GetTicketsPage = () => {
-  const pageTitle = 'Get Tickets';
+  const pageTitle = 'Get Tickets'
+  const description = 'A simple introduction to the tickets page with details to follow'
   return (
     <>
       <Head>
-        <PageTitle title={pageTitle} />
+        <title>Ohio DevFest Hackathon & Conference</title>
+        
         <meta
           name="description"
           content="The 2023 Ohio DevFest is a local tech conference hosted by Ohio-based Google Developer Groups (GDGs). It features talks, hands-on demos, workshops, and codelabs on the latest Google tech, plus featured talks intended to broaden interest and appeal."
         />
       </Head>
 
-      <PageTitle />
+      <PageTitle title={pageTitle} description={description} />
       <Newsletter />
     </>
   )


### PR DESCRIPTION
- Add centered nav below header section
- Add two new pages for content about Tickets and Sponsors
- Create PageTitle component to use with secondary pages to display H1 content 
- Pass info into component from each page 

