### PR TITLE
Create service-worker

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,12 @@
+// contents of service-worker.js
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function (registrations) {
+    for (let registration of registrations) {
+      //unregister service worker for old domain
+      registration.unregister()
+    }
+  }).catch(function (err) {
+    console.log('Fail: ', err);
+  });
+}


### PR DESCRIPTION
- Working to resolve Issue #26
- Request input if installing at `.../src/`is the correct path or to use `./`?
- Per Patrick Hammond email from August 4

> "The browser should *always attempt* to load the updated service worker file even if it has a cached version (otherwise the service worker could never be updated...no bueno) which led me to suggesting that returning the unregister/no-op service worker would break the cycle."

